### PR TITLE
Fix sources for install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def parse_requirements(fname='requirements.txt', with_version=True):
 ext_modules = [
     Extension(
         'xtcocotools._mask',
-        sources=['./common/maskApi.c', 'xtcocotools/_mask.pyx'],
+        sources=['xtcocotools/_mask.pyx'],
         include_dirs = [np.get_include(), './common'],
         extra_compile_args=[] # originally was ['-Wno-cpp', '-Wno-unused-function', '-std=c99'],
     )

--- a/xtcocotools/_mask.pyx
+++ b/xtcocotools/_mask.pyx
@@ -1,5 +1,5 @@
 # distutils: language = c
-# distutils: sources = ../common/maskApi.c
+# distutils: sources = common/maskApi.c
 
 #**************************************************************************
 # Microsoft COCO Toolbox.      version 2.0


### PR DESCRIPTION
I needed to update the path of maskApi.c and remove it from setup.py in order to build the library.
Installation through source was required since the pip install fails.